### PR TITLE
Fix wrong svg-mime type for no file extension

### DIFF
--- a/SVGImageMagickAdapter.php
+++ b/SVGImageMagickAdapter.php
@@ -31,7 +31,8 @@ class SVGImageMagickAdapter extends ImageMagick
      */
     public function validateUploadFile($filePath)
     {
-        if ($this->mime->getMimeType($filePath) === 'image/svg+xml') {
+        //Bug in getMimeType method found: Returns 'image/svg' in case of no file extension. See \Magento\Framework\File\Mime::getMimeType
+        if ($this->mime->getMimeType($filePath) === 'image/svg+xml' || $this->mime->getMimeType($filePath) === 'image/svg') {
             return true;
         }
         return parent::validateUploadFile($filePath);


### PR DESCRIPTION
Bug in getMimeType method found, when file has no file extension, e.g. when file is uploaded in product edit form. \Magento\Framework\File\Mime::getMimeType returns 'image/svg' instead of 'image/svg+xml'.